### PR TITLE
Adjusts equations for X2C, X2Y and Y2X

### DIFF
--- a/src/Magic.jl
+++ b/src/Magic.jl
@@ -2,6 +2,7 @@
 function Y2X(gas, Y)
     return Y ./ gas.MW / sum(Y./gas.MW)
 end
+Y2X(gas, Y, mean_MW) = Y2X(gas, Y)
 export Y2X
 
 "get concentration (C) from mass fraction (Y)"
@@ -26,6 +27,7 @@ export X2C
 function X2Y(gas, X)
     return X .* gas.MW / sum(X.*gas.MW)
 end
+X2Y(gas, X, mean_MW) = X2Y(gas, X)
 export X2Y
 
 """

--- a/src/Magic.jl
+++ b/src/Magic.jl
@@ -1,6 +1,6 @@
 "get mole fraction (X) from mass fraction (Y)"
-function Y2X(gas, Y, mean_MW)
-    return Y * mean_MW ./ gas.MW
+function Y2X(gas, Y)
+    return Y ./ gas.MW / sum(Y./gas.MW)
 end
 export Y2X
 
@@ -18,13 +18,13 @@ export C2X
 
 "get concentration (C) from mole fraction (X)"
 function X2C(gas, X, ρ_mass)
-    return X * ρ_mass ./ gas.MW
+    return X * ρ_mass / sum(X.*gas.MW)
 end
 export X2C
 
 "get mass fraction (Y) from mole fraction (X)"
-function X2Y(gas, X, mean_MW)
-    return X .* gas.MW / mean_MW
+function X2Y(gas, X)
+    return X .* gas.MW / sum(X.*gas.MW)
 end
 export X2Y
 


### PR DESCRIPTION
Equation for `X2C` is corrected, as suggested in https://github.com/DENG-MIT/Arrhenius.jl/issues/82
Functions `X2Y` and `Y2X` no longer require the mean molar mass as input argument.

If you don't want to change the API of the functions, feel free to change `mean_MW` to an optional argument instead of removing it.